### PR TITLE
多个切面时支持单个切面方法

### DIFF
--- a/Variant.hpp
+++ b/Variant.hpp
@@ -180,7 +180,7 @@ public:
 private:
 	void destroy(const std::type_index& index, void *buf)
 	{
-        [](Types&&...){}((destroy0<Types>(index, buf), 0)...);
+        [](...){}((destroy0<Types>(index, buf), 0)...);
 	}
 
 	template<typename T>
@@ -192,7 +192,7 @@ private:
 
 	void move(const std::type_index& old_t, void *old_v, void *new_v) 
 	{
-        [](Types&&...){}((move0<Types>(old_t, old_v, new_v), 0)...);
+        [](){}((move0<Types>(old_t, old_v, new_v), 0)...);
 	}
 
 	template<typename T>
@@ -204,7 +204,7 @@ private:
 
 	void copy(const std::type_index& old_t, const void *old_v, void *new_v)
 	{
-        [](Types&&...){}((copy0<Types>(old_t, old_v, new_v), 0)...);
+        [](){}((copy0<Types>(old_t, old_v, new_v), 0)...);
 	}
 
 	template<typename T>

--- a/Variant.hpp
+++ b/Variant.hpp
@@ -192,7 +192,7 @@ private:
 
 	void move(const std::type_index& old_t, void *old_v, void *new_v) 
 	{
-        [](){}((move0<Types>(old_t, old_v, new_v), 0)...);
+        [](...){}((move0<Types>(old_t, old_v, new_v), 0)...);
 	}
 
 	template<typename T>
@@ -204,7 +204,7 @@ private:
 
 	void copy(const std::type_index& old_t, const void *old_v, void *new_v)
 	{
-        [](){}((copy0<Types>(old_t, old_v, new_v), 0)...);
+        [](...){}((copy0<Types>(old_t, old_v, new_v), 0)...);
 	}
 
 	template<typename T>


### PR DESCRIPTION
以前的代码多个切面同时存在时不支持切面只实现单个切面方法（最后一个切面除外）， 测试代码如下:

```
#include "../cosmos/Aspect.hpp"

class A
{
public:
    void Before(){};
};

void test(){};

int main()
{
Invoke<A, A>(test);
return 0;
}
```

编译环境：
Ubuntu16.04TLS
g++ : 

> g++ (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609
> Copyright (C) 2015 Free Software Foundation, Inc.
> This is free software; see the source for copying conditions.  There is NO
> warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

编译错误如下：

> In file included from main.cpp:1:0:
> ../cosmos/Aspect.hpp: In instantiation of ‘void Aspect<Func, Args>::Invoke(Args&& ..., Head&&, Tail&& ...) [with Head = A; Tail = {A}; Func = void (&)(); Args = {}]’:
> ../cosmos/Aspect.hpp:87:2:   required from ‘void Invoke(Func&&, Args&& ...) [with AP = {A, A}; Args = {}; Func = void (&)()]’
> main.cpp:15:18:   required from here
> ../cosmos/Aspect.hpp:53:9: error: ‘class A’ has no member named ‘After’
>          headAspect.After(std::forward<Args>(args)...);

修改：
参见PR
