### PR TITLE
因为删除器bug无法二次Get，且unordered_map析构时候有未定义行为

### DIFF
--- a/pattern/ObjectPool.hpp
+++ b/pattern/ObjectPool.hpp
@@ -5,48 +5,56 @@
 #include "NonCopyable.hpp"
 using namespace std;
 
-const int MaxObjectNum = 10;
-
-template<typename T>
-class ObjectPool : NonCopyable
-{
-	template<typename... Args>
+template <typename T>
+class ObjectPool : NonCopyable {
+	template <typename... Args>
 	using Constructor = std::function<std::shared_ptr<T>(Args...)>;
 public:
+	struct ReEmplace {
+		void operator() (T* p) {
+			if (pool->isDestruct) {
+				delete p;
+			} else {
+				ReEmplace newRe(this->pool, this->conName);
+				pool->m_object_map.emplace(std::move(conName),
+					std::shared_ptr<T>(p, newRe));
+			}
+		}
+		ReEmplace(ObjectPool* p, const std::string& s) : pool(p), conName(s) {};
+		ObjectPool* pool;
+		std::string conName;
+	};
 	//默认创建多少个对象
-	template<typename... Args>
-	void Init(size_t num, Args&&... args)
-	{
-		if (num<= 0 || num> MaxObjectNum)
+	template <typename... Args>
+	void Init(size_t num, Args&&... args) {
+		if (num <= 0 || num > MaxObjectNum) {
 			throw std::logic_error("object num out of range.");
-
-		auto constructName = typeid(Constructor<Args...>).name(); //不区分引用
-		for (size_t i = 0; i <num; i++)
-		{
-			m_object_map.emplace(constructName, shared_ptr<T>(new T(std::forward<Args>(args)...), [this, constructName](T* p) //删除器中不直接删除对象，而是回收到对象池中，以供下次使用
-			{
-				m_object_map.emplace(std::move(constructName), std::shared_ptr<T>(p));
-			}));
+		}
+		auto constructName = typeid(Constructor<Args...>).name();//不区分引用
+		//删除器中不直接删除对象，而是回收到对象池中，以供下次使用
+		ReEmplace del(this, constructName);
+		for (size_t i = 0; i < num; i++) {
+			m_object_map.emplace(constructName, 
+				std::shared_ptr<T>(new T(std::forward<Args>(args)...), del)); 
 		}
 	}
-
 	//从对象池中获取一个对象
-	template<typename... Args>
-	std::shared_ptr<T> Get()
-	{
-		string constructName = typeid(Constructor<Args...>).name();
-
+	template <typename... Args>
+	std::shared_ptr<T> Get() {
+		std::string constructName = typeid(Constructor<Args...>).name();
 		auto range = m_object_map.equal_range(constructName);
-		for (auto it = range.first; it != range.second; ++it)
-		{
+		for (auto it = range.first; it != range.second; ++it) {
 			auto ptr = it->second;
 			m_object_map.erase(it);
 			return ptr;
 		}
-
 		return nullptr;
 	}
-
+	~ObjectPool() {
+		isDestruct = true;
+	}
 private:
-	multimap<string, std::shared_ptr<T>> m_object_map;
+	const size_t MaxObjectNum = 10;
+	std::multimap<std::string, std::shared_ptr<T>> m_object_map;
+	bool isDestruct = false;
 };


### PR DESCRIPTION
	ObjectPool<BigObject> pool;
	pool.Init(2);//初始化对象池，初始创建2个
	{
		auto p = pool.Get();
		PrintBigObject(p, "p");
		auto p2 = pool.Get();
		PrintBigObject(p2, "p2");
	}**//出了作用域之后，对象池返回出的对象又会自动回收。但是删除器调用时，重载放入map中的智能指针的删除器是默认删除器。**

	{
		auto p = pool.Get();
		auto p2 = pool.Get();
		PrintBigObject(p, "p");
		PrintBigObject(p2, "p2");
	}//这里结束之后，两个对象就delete了。

	{
		//对象池支持重载构造函数！map中现在有4个元素
		pool.Init(2, 1);
		auto p4 = pool.Get<int>();
		PrintBigObject(p4, "p4");
	}

	{
		//再多加两个元素
		pool.Init(2, 1, 2);
		auto p5 = pool.Get<int, int>();
		PrintBigObject(p5, "p4");
	}

**并且，在pool的map析构时候，调用的删除器尝试在map中重新emplace。VS2017测试出若干hang。**